### PR TITLE
Fix compilation on Linux

### DIFF
--- a/examples/common/render_common.h
+++ b/examples/common/render_common.h
@@ -34,17 +34,17 @@
 #include "../deps/gb_math.h"
 #include "../deps/sokol_app.h"
 
+#ifdef Always
+#undef Always // linux: X11.h --> WTF
+#undef None   // linux: X11.h --> WTF
+#endif
+
 #define PX_RENDER_IMPLEMENTATION
 #define PX_RENDER_IMGUI_IMPLEMENTATION
 #define PX_SCHED_IMPLEMENTATION
 #include "../../px_render.h"
 #include "../../px_sched.h"
 #include "../../px_render_imgui.h"
-
-#ifdef Always
-#undef Always // linux: X11.h --> WTF
-#undef None   // linux: X11.h --> WTF
-#endif
 
 void init(px_render::RenderContext *ctx, px_sched::Scheduler *sched);
 void finish(px_render::RenderContext *ctx, px_sched::Scheduler *sched);


### PR DESCRIPTION
`make -C examples` fails on Arch Linux with a lengthty:
```
g++ -std=c++14 -fpermissive -D linux -g -O2 -I . -o px_render_example_imgui px_render_example_imgui.cpp -lpthread -ldl -lX11
In file included from common/../deps/sokol_app.h:5487,
                 from common/render_common.h:35,
                 from px_render_example_imgui.cpp:1:
common/../../px_render.h:153:7: error: expected identifier before numeric constant
  153 |       None = 0,
      |       ^~~~
common/../../px_render.h:153:7: error: expected ‘}’ before numeric constant
In file included from common/render_common.h:40,
                 from px_render_example_imgui.cpp:1:
common/../../px_render.h:152:15: note: to match this ‘{’
  152 |     enum Enum {
      |               ^
In file included from common/../deps/sokol_app.h:5487,
                 from common/render_common.h:35,
                 from px_render_example_imgui.cpp:1:
common/../../px_render.h:153:7: error: expected unqualified-id before numeric constant
  153 |       None = 0,
      |       ^~~~
common/../../px_render.h:240:7: error: expected identifier before numeric constant
  240 |       Always,
      |       ^~~~~~
common/../../px_render.h:240:7: error: expected ‘}’ before numeric constant

<CUT>
```